### PR TITLE
feat: add usePublishedVariables() hook and documentation updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figma-vars/hooks",
-  "version": "2.0.0-beta.3",
+  "version": "2.1.0",
   "description": "Typed React hooks for managing Figma Variables, modes, tokens, and bindings via API.",
   "author": "Mark Learst",
   "license": "MIT",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -142,3 +142,21 @@ export { useDeleteVariable } from 'hooks/useDeleteVariable'
  * @public
  */
 export { useBulkUpdateVariables } from 'hooks/useBulkUpdateVariables'
+/**
+ * React hook to fetch published Figma Variables from a file.
+ *
+ * @remarks
+ * Fetches variables that have been published to a library. Published variables
+ * are shared across files and represent the source of truth for design tokens.
+ *
+ * @see {@link https://www.figma.com/developers/api#variables | Figma Variables API}
+ *
+ * @example
+ * ```tsx
+ * import { usePublishedVariables } from '@figma-vars/hooks';
+ * const { data, isLoading } = usePublishedVariables();
+ * ```
+ *
+ * @public
+ */
+export { usePublishedVariables } from 'hooks/usePublishedVariables'

--- a/src/hooks/usePublishedVariables.ts
+++ b/src/hooks/usePublishedVariables.ts
@@ -1,0 +1,76 @@
+import useSWR from 'swr'
+import { fetcher } from 'api/fetcher'
+import type { LocalVariablesResponse } from 'types/figma'
+import { useFigmaTokenContext } from 'contexts/useFigmaTokenContext'
+
+/**
+ * Hook to fetch published Figma Variables from a file.
+ *
+ * @remarks
+ * This hook fetches variables that have been published to a library in Figma.
+ * Published variables are shared across files and represent the "source of truth"
+ * for design tokens in a design system. Use this hook when you need to access
+ * variables that are consumed from a library, rather than local file variables.
+ *
+ * **When to use:**
+ * - Fetching design tokens from a published library
+ * - Building design system dashboards that track published tokens
+ * - Monitoring changes to shared variables across a design system
+ * - Validating consistency between published and local variables
+ *
+ * **Rate Limiting:**
+ * The Figma API has rate limits. Published variables are typically more stable
+ * than local variables, so they can be cached longer. SWR handles caching and
+ * revalidation automatically, but be mindful of frequent refetches in production.
+ *
+ * @returns SWR response object with `data`, `error`, `isLoading`, and `isValidating`.
+ *
+ * @public
+ *
+ * @example
+ * ```tsx
+ * import { usePublishedVariables } from '@figma-vars/hooks';
+ *
+ * function LibraryTokens() {
+ *   const { data, isLoading, error } = usePublishedVariables();
+ *
+ *   if (isLoading) return <div>Loading published variables...</div>;
+ *   if (error) return <div>Error: {error.message}</div>;
+ *
+ *   const variables = Object.values(data?.meta.variables ?? {});
+ *   return <ul>{variables.map(v => <li key={v.id}>{v.name}</li>)}</ul>;
+ * }
+ * ```
+ */
+export const usePublishedVariables = () => {
+  const { token, fileKey, fallbackFile } = useFigmaTokenContext()
+
+  // Create a custom fetcher that handles fallbackFile
+  const customFetcher = async (
+    url: string,
+    token: string
+  ): Promise<LocalVariablesResponse> => {
+    if (fallbackFile) {
+      return typeof fallbackFile === 'string'
+        ? (JSON.parse(fallbackFile) as LocalVariablesResponse)
+        : (fallbackFile as LocalVariablesResponse)
+    }
+    return fetcher<LocalVariablesResponse>(url, token)
+  }
+
+  // Use the published variables endpoint instead of local
+  const url =
+    token && fileKey
+      ? `https://api.figma.com/v1/files/${fileKey}/variables/published`
+      : null
+  const swrResponse = useSWR<LocalVariablesResponse>(
+    (url && token) || fallbackFile
+      ? ([url || 'fallback', token || 'fallback'] as const)
+      : null,
+    (url && token) || fallbackFile
+      ? ([u, t]: readonly [string, string]) => customFetcher(u, t)
+      : () => Promise.resolve(undefined as unknown as LocalVariablesResponse)
+  )
+
+  return swrResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export { FigmaVarsProvider } from 'contexts'
  */
 export {
   useVariables,
+  usePublishedVariables,
   useVariableCollections,
   useVariableModes,
   useCreateVariable,

--- a/tests/hooks/usePublishedVariables.test.tsx
+++ b/tests/hooks/usePublishedVariables.test.tsx
@@ -1,0 +1,311 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import useSWR from 'swr'
+import { describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+
+import { FigmaVarsProvider } from '../../src/contexts/FigmaVarsProvider'
+import { usePublishedVariables } from '../../src/hooks/usePublishedVariables'
+import { mockVariablesResponse } from '../mocks/variables'
+import type { ReactNode } from 'react'
+
+// Mock the useSWR hook
+vi.mock('swr')
+
+const mockedUseSWR = useSWR as Mock
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <FigmaVarsProvider
+    token='test-token'
+    fileKey='test-key'>
+    {children}
+  </FigmaVarsProvider>
+)
+
+const wrapperNoToken = ({ children }: { children: ReactNode }) => (
+  <FigmaVarsProvider
+    token={null}
+    fileKey='test-key'>
+    {children}
+  </FigmaVarsProvider>
+)
+
+const wrapperNoFileKey = ({ children }: { children: ReactNode }) => (
+  <FigmaVarsProvider
+    token='test-token'
+    fileKey={null}>
+    {children}
+  </FigmaVarsProvider>
+)
+
+const wrapperWithFallbackFile = ({ children }: { children: ReactNode }) => (
+  <FigmaVarsProvider
+    token='test-token'
+    fileKey='test-key'
+    fallbackFile={mockVariablesResponse}>
+    {children}
+  </FigmaVarsProvider>
+)
+
+const wrapperWithFallbackFileString = ({
+  children,
+}: {
+  children: ReactNode
+}) => (
+  <FigmaVarsProvider
+    token='test-token'
+    fileKey='test-key'
+    fallbackFile={JSON.stringify(mockVariablesResponse)}>
+    {children}
+  </FigmaVarsProvider>
+)
+
+const wrapperWithFallbackFileNoCredentials = ({
+  children,
+}: {
+  children: ReactNode
+}) => (
+  <FigmaVarsProvider
+    token={null}
+    fileKey={null}
+    fallbackFile={mockVariablesResponse}>
+    {children}
+  </FigmaVarsProvider>
+)
+
+describe('usePublishedVariables', () => {
+  it('should return loading state initially', () => {
+    mockedUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      isValidating: false,
+    })
+
+    const { result } = renderHook(() => usePublishedVariables(), { wrapper })
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.isValidating).toBe(false)
+  })
+
+  it('should return published variables on successful fetch', async () => {
+    mockedUseSWR.mockReturnValue({
+      data: mockVariablesResponse,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+    })
+
+    const { result } = renderHook(() => usePublishedVariables(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.data).toEqual(mockVariablesResponse)
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.isValidating).toBe(false)
+    })
+  })
+
+  it('should return an error when fetch fails', async () => {
+    const error = new Error('Failed to fetch')
+    mockedUseSWR.mockReturnValue({
+      data: undefined,
+      error: error,
+      isLoading: false,
+      isValidating: false,
+    })
+
+    const { result } = renderHook(() => usePublishedVariables(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.data).toBeUndefined()
+      expect(result.current.error).toBe(error)
+      expect(result.current.isValidating).toBe(false)
+    })
+  })
+
+  it('should return isValidating true when revalidating', () => {
+    mockedUseSWR.mockReturnValue({
+      data: mockVariablesResponse,
+      error: undefined,
+      isLoading: false,
+      isValidating: true,
+    })
+
+    const { result } = renderHook(() => usePublishedVariables(), { wrapper })
+
+    expect(result.current.isValidating).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('should not call useSWR when token is missing', () => {
+    mockedUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+    })
+
+    renderHook(() => usePublishedVariables(), { wrapper: wrapperNoToken })
+
+    expect(mockedUseSWR).toHaveBeenCalledWith(null, expect.any(Function))
+  })
+
+  it('should not call useSWR when fileKey is missing', () => {
+    mockedUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+    })
+
+    renderHook(() => usePublishedVariables(), { wrapper: wrapperNoFileKey })
+
+    expect(mockedUseSWR).toHaveBeenCalledWith(null, expect.any(Function))
+  })
+
+  it('should use fallbackFile when provided as object', () => {
+    // Mock the custom fetcher behavior for fallbackFile
+    mockedUseSWR.mockImplementation(key => {
+      if (key && Array.isArray(key) && key[0] && key[1]) {
+        // Simulate the custom fetcher being called and returning fallback data
+        return {
+          data: mockVariablesResponse,
+          error: null,
+          isLoading: false,
+          isValidating: false,
+        }
+      }
+      return {
+        data: undefined,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+      }
+    })
+
+    const { result } = renderHook(() => usePublishedVariables(), {
+      wrapper: wrapperWithFallbackFile,
+    })
+
+    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.error).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isValidating).toBe(false)
+  })
+
+  it('should use fallbackFile when provided as string', () => {
+    // Mock the custom fetcher behavior for fallbackFile string
+    mockedUseSWR.mockImplementation(key => {
+      if (key && Array.isArray(key) && key[0] && key[1]) {
+        // Simulate the custom fetcher being called and returning fallback data
+        return {
+          data: mockVariablesResponse,
+          error: null,
+          isLoading: false,
+          isValidating: false,
+        }
+      }
+      return {
+        data: undefined,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+      }
+    })
+
+    const { result } = renderHook(() => usePublishedVariables(), {
+      wrapper: wrapperWithFallbackFileString,
+    })
+
+    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.error).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isValidating).toBe(false)
+  })
+
+  it('should use fallbackFile when both token and fileKey are null', () => {
+    // Mock the custom fetcher behavior for fallbackFile when both token and fileKey are null
+    mockedUseSWR.mockImplementation(key => {
+      if (key && Array.isArray(key) && key[0] && key[1]) {
+        // Simulate the custom fetcher being called and returning fallback data
+        return {
+          data: mockVariablesResponse,
+          error: null,
+          isLoading: false,
+          isValidating: false,
+        }
+      }
+      return {
+        data: undefined,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+      }
+    })
+
+    const { result } = renderHook(() => usePublishedVariables(), {
+      wrapper: wrapperWithFallbackFileNoCredentials,
+    })
+
+    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.error).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isValidating).toBe(false)
+  })
+
+  it('should test custom fetcher logic directly for published endpoint', async () => {
+    // Test the actual custom fetcher logic by calling it directly
+    renderHook(() => usePublishedVariables(), {
+      wrapper: wrapperWithFallbackFile,
+    })
+
+    // Get the custom fetcher function from the useSWR call
+    const useSWRCalls = mockedUseSWR.mock.calls
+    expect(useSWRCalls.length).toBeGreaterThan(0)
+
+    const call = useSWRCalls[0]
+    expect(call).toBeDefined()
+    const [key, fetcher] = call as [
+      unknown,
+      (url: string, token: string) => Promise<unknown>,
+    ]
+    // Verify it's using the published endpoint, not local
+    expect(key).toEqual([
+      'https://api.figma.com/v1/files/test-key/variables/published',
+      'test-token',
+    ])
+    expect(typeof fetcher).toBe('function')
+
+    // Call the custom fetcher directly to test the fallbackFile logic
+    const resultData = await fetcher(
+      'https://api.figma.com/v1/files/test-key/variables/published',
+      'test-token'
+    )
+    expect(resultData).toEqual(mockVariablesResponse)
+  })
+
+  it('should test custom fetcher logic with no credentials', async () => {
+    // Test the actual custom fetcher logic by calling it directly when both token and fileKey are null
+    renderHook(() => usePublishedVariables(), {
+      wrapper: wrapperWithFallbackFileNoCredentials,
+    })
+
+    // Get the custom fetcher function from the useSWR call
+    const useSWRCalls = mockedUseSWR.mock.calls
+    expect(useSWRCalls.length).toBeGreaterThan(0)
+
+    const call = useSWRCalls[0]
+    expect(call).toBeDefined()
+    const [key, fetcher] = call as [
+      unknown,
+      (url: string, token: string) => Promise<unknown>,
+    ]
+    expect(key).toEqual(['fallback', 'fallback'])
+    expect(typeof fetcher).toBe('function')
+
+    // Call the custom fetcher directly to test the fallbackFile logic
+    const resultData = await fetcher('fallback', 'fallback')
+    expect(resultData).toEqual(mockVariablesResponse)
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds the `usePublishedVariables()` hook and improves documentation to better support design systems using published Figma libraries.

### Changes

- ✅ **New Feature**: `usePublishedVariables()` hook for fetching published library variables
- ✅ **Tests**: Comprehensive test coverage (11 tests) for the new hook
- ✅ **Documentation**: Added rate limit information and best practices
- ✅ **Documentation**: Clear guidance on when to use local vs. published variables
- ✅ **Version**: Minor bump to 2.1.0

### Why This Matters

Published variables represent the source of truth for design tokens in design systems. This hook makes it easy to:
- Build design system dashboards that track published tokens
- Monitor consistency across files that consume the same library
- Validate that local variables match published tokens
- Access read-only, stable design tokens efficiently

### Test Plan

- [x] All 94 tests pass (including 11 new tests for `usePublishedVariables()`)
- [x] New hook follows the same pattern as `useVariables()`
- [x] Supports both API and fallback file modes
- [x] Documentation includes practical examples and rate limit guidance

### Breaking Changes

None - this is a pure feature addition with backward compatibility.