### PR TITLE
fix(api): normalize URL handling in fetcher/mutator

### DIFF
--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -1,6 +1,7 @@
 // utils/fetchHelpers.ts
 
 import {
+  FIGMA_API_BASE_URL,
   FIGMA_TOKEN_HEADER,
   CONTENT_TYPE_JSON,
   ERROR_MSG_TOKEN_REQUIRED,
@@ -42,7 +43,12 @@ export async function fetcher<TResponse = unknown>(
     throw new Error(ERROR_MSG_TOKEN_REQUIRED)
   }
 
-  const response = await fetch(url, {
+  const requestUrl =
+    url.startsWith('http://') || url.startsWith('https://')
+      ? url
+      : `${FIGMA_API_BASE_URL}${url.startsWith('/') ? '' : '/'}${url}`
+
+  const response = await fetch(requestUrl, {
     method: 'GET',
     headers: {
       [FIGMA_TOKEN_HEADER]: token,

--- a/src/api/mutator.ts
+++ b/src/api/mutator.ts
@@ -66,7 +66,13 @@ export async function mutator<
   if (body) {
     init.body = JSON.stringify(body)
   }
-  const response = await fetch(`${FIGMA_API_BASE_URL}${url}`, init)
+
+  const requestUrl =
+    url.startsWith('http://') || url.startsWith('https://')
+      ? url
+      : `${FIGMA_API_BASE_URL}${url.startsWith('/') ? '' : '/'}${url}`
+
+  const response = await fetch(requestUrl, init)
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}))

--- a/tests/api/fetcher.test.ts
+++ b/tests/api/fetcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { fetcher } from '../../src/api/fetcher'
+import { FIGMA_API_BASE_URL } from '../../src/constants'
 
 const DUMMY_URL = 'https://api.example.com/test'
 const DUMMY_TOKEN = 'dummy-token'
@@ -32,6 +33,25 @@ describe('fetcher', () => {
     expect(result).toEqual(data)
     expect(global.fetch).toHaveBeenCalledWith(
       DUMMY_URL,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-FIGMA-TOKEN': DUMMY_TOKEN,
+          'Content-Type': 'application/json',
+        }),
+      })
+    )
+  })
+
+  it('prefixes FIGMA_API_BASE_URL when url is a path', async () => {
+    const data = { foo: 'bar' }
+    const path = '/v1/files/abc/variables/local'
+    mockFetch({ json: () => Promise.resolve(data) })
+
+    const result = await fetcher(path, DUMMY_TOKEN)
+
+    expect(result).toEqual(data)
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${FIGMA_API_BASE_URL}${path}`,
       expect.objectContaining({
         headers: expect.objectContaining({
           'X-FIGMA-TOKEN': DUMMY_TOKEN,

--- a/tests/api/mutator.test.ts
+++ b/tests/api/mutator.test.ts
@@ -12,6 +12,7 @@ global.fetch = mockFetch
 describe('mutator', () => {
   const token = 'test-token'
   const url = '/variables'
+  const fullUrl = `${FIGMA_API_BASE_URL}${url}`
   const body = { name: 'test' }
 
   afterEach(() => {
@@ -52,6 +53,22 @@ describe('mutator', () => {
       expect.objectContaining({ method: 'PUT' })
     )
     expect(result).toEqual({ id: '123' })
+  })
+
+  it('should not prefix base URL when url is already absolute', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: 'not-null',
+      json: () => Promise.resolve({ id: '123' }),
+    })
+
+    await mutator(fullUrl, token, 'CREATE', body)
+
+    expect(fetch).toHaveBeenCalledWith(
+      fullUrl,
+      expect.objectContaining({ method: 'POST' })
+    )
   })
 
   it('should handle successful DELETE (204 No Content)', async () => {


### PR DESCRIPTION
# Summary

- Fixes URL handling so `fetcher` and `mutator` accept either absolute URLs (e.g. `https://api.figma.com/...`) or path-only endpoints (e.g. `/v1/...`).

# Motivation

- Some call sites and constants provide full URLs, while other internal utilities/tests use path-only endpoints.
- `mutator` previously always prefixed `FIGMA_API_BASE_URL`, which could produce invalid requests like `https://api.figma.comhttps://api.figma.com/...`.

# Changes

- `mutator`: detect absolute URLs and avoid double-prefixing; prefix only when given a path.
- `fetcher`: align behavior with `mutator` by supporting path-only endpoints as well.
- Tests: add regression coverage for both absolute-url and path-url cases.

# Verification

- `pnpm test`