### PR TITLE
fix(types): add strict published variables response

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -30,6 +30,9 @@ const FIGMA_V1_VARIABLES_ENDPOINT_BASE = `${FIGMA_API_BASE_URL}/v1/variables`
 export const FIGMA_VARIABLES_ENDPOINT = (fileKey: string) =>
   `${FIGMA_FILES_ENDPOINT}/${fileKey}/variables`
 
+export const FIGMA_PUBLISHED_VARIABLES_PATH = (fileKey: string) =>
+  `/v1/files/${fileKey}/variables/published`
+
 /**
  * The base endpoint for creating new variables via POST requests.
  */

--- a/src/hooks/usePublishedVariables.ts
+++ b/src/hooks/usePublishedVariables.ts
@@ -1,7 +1,8 @@
 import useSWR from 'swr'
 import { fetcher } from 'api/fetcher'
-import type { LocalVariablesResponse } from 'types/figma'
+import type { PublishedVariablesResponse } from 'types/figma'
 import { useFigmaTokenContext } from 'contexts/useFigmaTokenContext'
+import { FIGMA_PUBLISHED_VARIABLES_PATH } from 'constants/index'
 
 /**
  * Hook to fetch published Figma Variables from a file.
@@ -49,27 +50,26 @@ export const usePublishedVariables = () => {
   const customFetcher = async (
     url: string,
     token: string
-  ): Promise<LocalVariablesResponse> => {
+  ): Promise<PublishedVariablesResponse> => {
     if (fallbackFile) {
-      return typeof fallbackFile === 'string'
-        ? (JSON.parse(fallbackFile) as LocalVariablesResponse)
-        : (fallbackFile as LocalVariablesResponse)
+      if (typeof fallbackFile === 'string') {
+        return JSON.parse(fallbackFile) as PublishedVariablesResponse
+      }
+      return fallbackFile as unknown as PublishedVariablesResponse
     }
-    return fetcher<LocalVariablesResponse>(url, token)
+    return fetcher<PublishedVariablesResponse>(url, token)
   }
 
   // Use the published variables endpoint instead of local
-  const url =
-    token && fileKey
-      ? `https://api.figma.com/v1/files/${fileKey}/variables/published`
-      : null
-  const swrResponse = useSWR<LocalVariablesResponse>(
+  const url = token && fileKey ? FIGMA_PUBLISHED_VARIABLES_PATH(fileKey) : null
+  const swrResponse = useSWR<PublishedVariablesResponse>(
     (url && token) || fallbackFile
       ? ([url || 'fallback', token || 'fallback'] as const)
       : null,
     (url && token) || fallbackFile
       ? ([u, t]: readonly [string, string]) => customFetcher(u, t)
-      : () => Promise.resolve(undefined as unknown as LocalVariablesResponse)
+      : () =>
+          Promise.resolve(undefined as unknown as PublishedVariablesResponse)
   )
 
   return swrResponse

--- a/src/types/contexts.ts
+++ b/src/types/contexts.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import type { LocalVariablesResponse } from 'types'
+import type { LocalVariablesResponse, PublishedVariablesResponse } from 'types'
 
 /**
  * Central context shape for FigmaVars—provides authentication and file context to all hooks and consumers in the tree.
@@ -42,7 +42,7 @@ export interface FigmaTokenContextType {
    * Optional fallback variable JSON file for offline or static use cases.
    * Allows FigmaVars to function without a live API request.
    */
-  fallbackFile?: LocalVariablesResponse | string
+  fallbackFile?: LocalVariablesResponse | PublishedVariablesResponse | string
 }
 
 /**
@@ -85,5 +85,5 @@ export interface FigmaVarsProviderProps {
   /**
    * Optional fallback variable JSON file used when the API is unavailable or skipped.
    */
-  fallbackFile?: LocalVariablesResponse | string
+  fallbackFile?: LocalVariablesResponse | PublishedVariablesResponse | string
 }

--- a/src/types/figma.ts
+++ b/src/types/figma.ts
@@ -248,6 +248,31 @@ export interface LocalVariablesResponse {
   }
 }
 
+export interface PublishedVariable {
+  id: string
+  subscribed_id: string
+  name: string
+  key: string
+  variableCollectionId: string
+  resolvedType: ResolvedType
+  updatedAt: string
+}
+
+export interface PublishedVariableCollection {
+  id: string
+  subscribed_id: string
+  name: string
+  key: string
+  updatedAt: string
+}
+
+export interface PublishedVariablesResponse {
+  meta: {
+    variableCollections: Record<string, PublishedVariableCollection>
+    variables: Record<string, PublishedVariable>
+  }
+}
+
 /**
  * Standard error response shape for Figma API error objects.
  *

--- a/tests/hooks/usePublishedVariables.test.tsx
+++ b/tests/hooks/usePublishedVariables.test.tsx
@@ -5,7 +5,11 @@ import type { Mock } from 'vitest'
 
 import { FigmaVarsProvider } from '../../src/contexts/FigmaVarsProvider'
 import { usePublishedVariables } from '../../src/hooks/usePublishedVariables'
-import { mockVariablesResponse } from '../mocks/variables'
+import {
+  mockLocalVariablesResponse,
+  mockPublishedVariablesResponse,
+} from '../mocks/variables'
+import { FIGMA_PUBLISHED_VARIABLES_PATH } from '../../src/constants'
 import type { ReactNode } from 'react'
 
 // Mock the useSWR hook
@@ -41,7 +45,7 @@ const wrapperWithFallbackFile = ({ children }: { children: ReactNode }) => (
   <FigmaVarsProvider
     token='test-token'
     fileKey='test-key'
-    fallbackFile={mockVariablesResponse}>
+    fallbackFile={mockPublishedVariablesResponse}>
     {children}
   </FigmaVarsProvider>
 )
@@ -54,7 +58,7 @@ const wrapperWithFallbackFileString = ({
   <FigmaVarsProvider
     token='test-token'
     fileKey='test-key'
-    fallbackFile={JSON.stringify(mockVariablesResponse)}>
+    fallbackFile={JSON.stringify(mockPublishedVariablesResponse)}>
     {children}
   </FigmaVarsProvider>
 )
@@ -67,7 +71,7 @@ const wrapperWithFallbackFileNoCredentials = ({
   <FigmaVarsProvider
     token={null}
     fileKey={null}
-    fallbackFile={mockVariablesResponse}>
+    fallbackFile={mockPublishedVariablesResponse}>
     {children}
   </FigmaVarsProvider>
 )
@@ -89,7 +93,7 @@ describe('usePublishedVariables', () => {
 
   it('should return published variables on successful fetch', async () => {
     mockedUseSWR.mockReturnValue({
-      data: mockVariablesResponse,
+      data: mockPublishedVariablesResponse,
       error: undefined,
       isLoading: false,
       isValidating: false,
@@ -99,7 +103,7 @@ describe('usePublishedVariables', () => {
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false)
-      expect(result.current.data).toEqual(mockVariablesResponse)
+      expect(result.current.data).toEqual(mockPublishedVariablesResponse)
       expect(result.current.error).toBeUndefined()
       expect(result.current.isValidating).toBe(false)
     })
@@ -126,7 +130,7 @@ describe('usePublishedVariables', () => {
 
   it('should return isValidating true when revalidating', () => {
     mockedUseSWR.mockReturnValue({
-      data: mockVariablesResponse,
+      data: mockPublishedVariablesResponse,
       error: undefined,
       isLoading: false,
       isValidating: true,
@@ -170,7 +174,7 @@ describe('usePublishedVariables', () => {
       if (key && Array.isArray(key) && key[0] && key[1]) {
         // Simulate the custom fetcher being called and returning fallback data
         return {
-          data: mockVariablesResponse,
+          data: mockPublishedVariablesResponse,
           error: null,
           isLoading: false,
           isValidating: false,
@@ -188,7 +192,7 @@ describe('usePublishedVariables', () => {
       wrapper: wrapperWithFallbackFile,
     })
 
-    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.data).toEqual(mockPublishedVariablesResponse)
     expect(result.current.error).toBeNull()
     expect(result.current.isLoading).toBe(false)
     expect(result.current.isValidating).toBe(false)
@@ -200,7 +204,7 @@ describe('usePublishedVariables', () => {
       if (key && Array.isArray(key) && key[0] && key[1]) {
         // Simulate the custom fetcher being called and returning fallback data
         return {
-          data: mockVariablesResponse,
+          data: mockPublishedVariablesResponse,
           error: null,
           isLoading: false,
           isValidating: false,
@@ -218,7 +222,7 @@ describe('usePublishedVariables', () => {
       wrapper: wrapperWithFallbackFileString,
     })
 
-    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.data).toEqual(mockPublishedVariablesResponse)
     expect(result.current.error).toBeNull()
     expect(result.current.isLoading).toBe(false)
     expect(result.current.isValidating).toBe(false)
@@ -230,7 +234,7 @@ describe('usePublishedVariables', () => {
       if (key && Array.isArray(key) && key[0] && key[1]) {
         // Simulate the custom fetcher being called and returning fallback data
         return {
-          data: mockVariablesResponse,
+          data: mockPublishedVariablesResponse,
           error: null,
           isLoading: false,
           isValidating: false,
@@ -248,7 +252,7 @@ describe('usePublishedVariables', () => {
       wrapper: wrapperWithFallbackFileNoCredentials,
     })
 
-    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.data).toEqual(mockPublishedVariablesResponse)
     expect(result.current.error).toBeNull()
     expect(result.current.isLoading).toBe(false)
     expect(result.current.isValidating).toBe(false)
@@ -272,17 +276,17 @@ describe('usePublishedVariables', () => {
     ]
     // Verify it's using the published endpoint, not local
     expect(key).toEqual([
-      'https://api.figma.com/v1/files/test-key/variables/published',
+      FIGMA_PUBLISHED_VARIABLES_PATH('test-key'),
       'test-token',
     ])
     expect(typeof fetcher).toBe('function')
 
     // Call the custom fetcher directly to test the fallbackFile logic
     const resultData = await fetcher(
-      'https://api.figma.com/v1/files/test-key/variables/published',
+      FIGMA_PUBLISHED_VARIABLES_PATH('test-key'),
       'test-token'
     )
-    expect(resultData).toEqual(mockVariablesResponse)
+    expect(resultData).toEqual(mockPublishedVariablesResponse)
   })
 
   it('should test custom fetcher logic with no credentials', async () => {
@@ -306,6 +310,12 @@ describe('usePublishedVariables', () => {
 
     // Call the custom fetcher directly to test the fallbackFile logic
     const resultData = await fetcher('fallback', 'fallback')
-    expect(resultData).toEqual(mockVariablesResponse)
+    expect(resultData).toEqual(mockPublishedVariablesResponse)
+  })
+
+  it('should not affect local variables mocks used by other tests', () => {
+    expect(
+      mockLocalVariablesResponse.meta.variables['VariableID:1:1']
+    ).toBeDefined()
   })
 })

--- a/tests/hooks/useVariableCollections.test.tsx
+++ b/tests/hooks/useVariableCollections.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import type { Mock } from 'vitest'
 import { useVariableCollections } from '../../src/hooks/useVariableCollections'
 import { useVariables } from '../../src/hooks/useVariables'
-import { mockVariablesResponse } from '../../tests/mocks/variables'
+import { mockLocalVariablesResponse } from '../../tests/mocks/variables'
 
 vi.mock('../../src/hooks/useVariables')
 
@@ -21,15 +21,15 @@ describe('useVariableCollections', () => {
 
   it('should return collections when useVariables has data', () => {
     mockedUseVariables.mockReturnValue({
-      data: mockVariablesResponse,
+      data: mockLocalVariablesResponse,
     })
     const { result } = renderHook(() => useVariableCollections())
 
     const expectedCollections = Object.values(
-      mockVariablesResponse.meta.variableCollections
+      mockLocalVariablesResponse.meta.variableCollections
     )
     const expectedCollectionsById =
-      mockVariablesResponse.meta.variableCollections
+      mockLocalVariablesResponse.meta.variableCollections
 
     expect(result.current.collections).toEqual(expectedCollections)
     expect(result.current.collectionsById).toEqual(expectedCollectionsById)
@@ -37,7 +37,7 @@ describe('useVariableCollections', () => {
 
   it('should memoize the result and not re-calculate on re-render', () => {
     const mockData = {
-      data: mockVariablesResponse,
+      data: mockLocalVariablesResponse,
     }
     mockedUseVariables.mockReturnValue(mockData)
 

--- a/tests/hooks/useVariableModes.test.tsx
+++ b/tests/hooks/useVariableModes.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 import type { Mock } from 'vitest'
 import { useVariableModes } from '../../src/hooks/useVariableModes'
 import { useVariables } from '../../src/hooks/useVariables'
-import { mockVariablesResponse } from '../../tests/mocks/variables'
+import { mockLocalVariablesResponse } from '../../tests/mocks/variables'
 
 vi.mock('../../src/hooks/useVariables')
 
@@ -22,11 +22,11 @@ describe('useVariableModes', () => {
 
   it('should return processed modes when useVariables has data', () => {
     mockedUseVariables.mockReturnValue({
-      data: mockVariablesResponse,
+      data: mockLocalVariablesResponse,
     })
     const { result } = renderHook(() => useVariableModes())
 
-    const { variableCollections } = mockVariablesResponse.meta
+    const { variableCollections } = mockLocalVariablesResponse.meta
     const collection1 = Object.values(variableCollections)[0]!
     const collection2 = Object.values(variableCollections)[1]!
 
@@ -48,7 +48,7 @@ describe('useVariableModes', () => {
 
   it('should memoize the result', () => {
     const mockData = {
-      data: mockVariablesResponse,
+      data: mockLocalVariablesResponse,
     }
     mockedUseVariables.mockReturnValue(mockData)
 

--- a/tests/hooks/useVariables.test.tsx
+++ b/tests/hooks/useVariables.test.tsx
@@ -5,7 +5,7 @@ import type { Mock } from 'vitest'
 
 import { FigmaVarsProvider } from '../../src/contexts/FigmaVarsProvider'
 import { useVariables } from '../../src/hooks/useVariables'
-import { mockVariablesResponse } from '../mocks/variables'
+import { mockLocalVariablesResponse } from '../mocks/variables'
 import type { ReactNode } from 'react'
 
 // Mock the useSWR hook
@@ -41,7 +41,7 @@ const wrapperWithFallbackFile = ({ children }: { children: ReactNode }) => (
   <FigmaVarsProvider
     token='test-token'
     fileKey='test-key'
-    fallbackFile={mockVariablesResponse}>
+    fallbackFile={mockLocalVariablesResponse}>
     {children}
   </FigmaVarsProvider>
 )
@@ -54,7 +54,7 @@ const wrapperWithFallbackFileString = ({
   <FigmaVarsProvider
     token='test-token'
     fileKey='test-key'
-    fallbackFile={JSON.stringify(mockVariablesResponse)}>
+    fallbackFile={JSON.stringify(mockLocalVariablesResponse)}>
     {children}
   </FigmaVarsProvider>
 )
@@ -67,7 +67,7 @@ const wrapperWithFallbackFileNoCredentials = ({
   <FigmaVarsProvider
     token={null}
     fileKey={null}
-    fallbackFile={mockVariablesResponse}>
+    fallbackFile={mockLocalVariablesResponse}>
     {children}
   </FigmaVarsProvider>
 )
@@ -89,7 +89,7 @@ describe('useVariables', () => {
 
   it('should return variables on successful fetch', async () => {
     mockedUseSWR.mockReturnValue({
-      data: mockVariablesResponse,
+      data: mockLocalVariablesResponse,
       error: undefined,
       isLoading: false,
       isValidating: false,
@@ -99,7 +99,7 @@ describe('useVariables', () => {
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false)
-      expect(result.current.data).toEqual(mockVariablesResponse)
+      expect(result.current.data).toEqual(mockLocalVariablesResponse)
       expect(result.current.error).toBeUndefined()
       expect(result.current.isValidating).toBe(false)
     })
@@ -126,7 +126,7 @@ describe('useVariables', () => {
 
   it('should return isValidating true when revalidating', () => {
     mockedUseSWR.mockReturnValue({
-      data: mockVariablesResponse,
+      data: mockLocalVariablesResponse,
       error: undefined,
       isLoading: false,
       isValidating: true,
@@ -170,7 +170,7 @@ describe('useVariables', () => {
       if (key && Array.isArray(key) && key[0] && key[1]) {
         // Simulate the custom fetcher being called and returning fallback data
         return {
-          data: mockVariablesResponse,
+          data: mockLocalVariablesResponse,
           error: null,
           isLoading: false,
           isValidating: false,
@@ -188,7 +188,7 @@ describe('useVariables', () => {
       wrapper: wrapperWithFallbackFile,
     })
 
-    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.data).toEqual(mockLocalVariablesResponse)
     expect(result.current.error).toBeNull()
     expect(result.current.isLoading).toBe(false)
     expect(result.current.isValidating).toBe(false)
@@ -200,7 +200,7 @@ describe('useVariables', () => {
       if (key && Array.isArray(key) && key[0] && key[1]) {
         // Simulate the custom fetcher being called and returning fallback data
         return {
-          data: mockVariablesResponse,
+          data: mockLocalVariablesResponse,
           error: null,
           isLoading: false,
           isValidating: false,
@@ -218,7 +218,7 @@ describe('useVariables', () => {
       wrapper: wrapperWithFallbackFileString,
     })
 
-    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.data).toEqual(mockLocalVariablesResponse)
     expect(result.current.error).toBeNull()
     expect(result.current.isLoading).toBe(false)
     expect(result.current.isValidating).toBe(false)
@@ -230,7 +230,7 @@ describe('useVariables', () => {
       if (key && Array.isArray(key) && key[0] && key[1]) {
         // Simulate the custom fetcher being called and returning fallback data
         return {
-          data: mockVariablesResponse,
+          data: mockLocalVariablesResponse,
           error: null,
           isLoading: false,
           isValidating: false,
@@ -248,7 +248,7 @@ describe('useVariables', () => {
       wrapper: wrapperWithFallbackFileNoCredentials,
     })
 
-    expect(result.current.data).toEqual(mockVariablesResponse)
+    expect(result.current.data).toEqual(mockLocalVariablesResponse)
     expect(result.current.error).toBeNull()
     expect(result.current.isLoading).toBe(false)
     expect(result.current.isValidating).toBe(false)
@@ -279,7 +279,7 @@ describe('useVariables', () => {
       'https://api.figma.com/v1/files/test-key/variables/local',
       'test-token'
     )
-    expect(resultData).toEqual(mockVariablesResponse)
+    expect(resultData).toEqual(mockLocalVariablesResponse)
   })
 
   it('should test custom fetcher logic with no credentials', async () => {
@@ -303,6 +303,6 @@ describe('useVariables', () => {
 
     // Call the custom fetcher directly to test the fallbackFile logic
     const resultData = await fetcher('fallback', 'fallback')
-    expect(resultData).toEqual(mockVariablesResponse)
+    expect(resultData).toEqual(mockLocalVariablesResponse)
   })
 })

--- a/tests/mocks/variables.ts
+++ b/tests/mocks/variables.ts
@@ -1,6 +1,9 @@
-import type { LocalVariablesResponse } from '../../src/types'
+import type {
+  LocalVariablesResponse,
+  PublishedVariablesResponse,
+} from '../../src/types'
 
-export const mockVariablesResponse: LocalVariablesResponse = {
+export const mockLocalVariablesResponse: LocalVariablesResponse = {
   meta: {
     variableCollections: {
       'VariableCollectionId:123:456': {
@@ -51,6 +54,31 @@ export const mockVariablesResponse: LocalVariablesResponse = {
         hiddenFromPublishing: false,
         scopes: ['ALL_SCOPES'],
         codeSyntax: {},
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    },
+  },
+}
+
+export const mockPublishedVariablesResponse: PublishedVariablesResponse = {
+  meta: {
+    variableCollections: {
+      'VariableCollectionId:123:456': {
+        id: 'VariableCollectionId:123:456',
+        subscribed_id: 'SubscribedVariableCollectionId:123:456',
+        name: 'Test Collection 1',
+        key: 'collection-key-1',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    },
+    variables: {
+      'VariableID:1:1': {
+        id: 'VariableID:1:1',
+        subscribed_id: 'SubscribedVariableID:1:1',
+        name: 'colors/primary',
+        key: 'variable-key-1',
+        variableCollectionId: 'VariableCollectionId:123:456',
+        resolvedType: 'COLOR',
         updatedAt: '2024-01-01T00:00:00Z',
       },
     },


### PR DESCRIPTION
- Introduces PublishedVariablesResponse types matching Figma published variables endpoint (subscribed_id, updatedAt, no modes)

- Updates usePublishedVariables to return PublishedVariablesResponse (strict typing; no union)

- Switches published endpoint usage to FIGMA_PUBLISHED_VARIABLES_PATH (path-only)

- Updates context fallbackFile typing to support published response shapes

- Updates mocks and tests to use distinct local vs published fixtures