### PR TITLE
fix(api): use file-scoped bulk variables mutations

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -33,6 +33,9 @@ export const FIGMA_VARIABLES_ENDPOINT = (fileKey: string) =>
 export const FIGMA_PUBLISHED_VARIABLES_PATH = (fileKey: string) =>
   `/v1/files/${fileKey}/variables/published`
 
+export const FIGMA_FILE_VARIABLES_PATH = (fileKey: string) =>
+  `/v1/files/${fileKey}/variables`
+
 /**
  * The base endpoint for creating new variables via POST requests.
  */

--- a/src/hooks/useBulkUpdateVariables.ts
+++ b/src/hooks/useBulkUpdateVariables.ts
@@ -2,8 +2,9 @@ import { useFigmaTokenContext } from 'contexts/useFigmaTokenContext'
 import { useMutation } from 'hooks/useMutation'
 import type { BulkUpdatePayload } from 'types/mutations'
 import {
-  FIGMA_POST_VARIABLES_ENDPOINT,
+  FIGMA_FILE_VARIABLES_PATH,
   ERROR_MSG_TOKEN_REQUIRED,
+  ERROR_MSG_TOKEN_FILE_KEY_REQUIRED,
 } from 'constants/index'
 import { mutator } from 'api/mutator'
 
@@ -36,13 +37,16 @@ import { mutator } from 'api/mutator'
  * @public
  */
 export const useBulkUpdateVariables = () => {
-  const { token } = useFigmaTokenContext()
+  const { token, fileKey } = useFigmaTokenContext()
   const mutation = useMutation(async (payload: BulkUpdatePayload) => {
     if (!token) {
       throw new Error(ERROR_MSG_TOKEN_REQUIRED)
     }
+    if (!fileKey) {
+      throw new Error(ERROR_MSG_TOKEN_FILE_KEY_REQUIRED)
+    }
     return await mutator(
-      FIGMA_POST_VARIABLES_ENDPOINT,
+      FIGMA_FILE_VARIABLES_PATH(fileKey),
       token,
       'CREATE',
       payload as unknown as Record<string, unknown>

--- a/src/hooks/useCreateVariable.ts
+++ b/src/hooks/useCreateVariable.ts
@@ -2,8 +2,9 @@ import { useFigmaTokenContext } from 'contexts/useFigmaTokenContext'
 import { useMutation } from 'hooks/useMutation'
 import type { CreateVariablePayload } from 'types/mutations'
 import {
-  FIGMA_POST_VARIABLES_ENDPOINT,
+  FIGMA_FILE_VARIABLES_PATH,
   ERROR_MSG_TOKEN_REQUIRED,
+  ERROR_MSG_TOKEN_FILE_KEY_REQUIRED,
 } from 'constants/index'
 import { mutator } from 'api/mutator'
 
@@ -33,17 +34,22 @@ import { mutator } from 'api/mutator'
  * @public
  */
 export const useCreateVariable = () => {
-  const { token } = useFigmaTokenContext()
+  const { token, fileKey } = useFigmaTokenContext()
   const mutation = useMutation(async (payload: CreateVariablePayload) => {
     if (!token) {
       throw new Error(ERROR_MSG_TOKEN_REQUIRED)
     }
-    return await mutator(
-      FIGMA_POST_VARIABLES_ENDPOINT,
-      token,
-      'CREATE',
-      payload as unknown as Record<string, unknown>
-    )
+    if (!fileKey) {
+      throw new Error(ERROR_MSG_TOKEN_FILE_KEY_REQUIRED)
+    }
+    return await mutator(FIGMA_FILE_VARIABLES_PATH(fileKey), token, 'CREATE', {
+      variables: [
+        {
+          action: 'CREATE',
+          ...payload,
+        },
+      ],
+    } as unknown as Record<string, unknown>)
   })
   return mutation
 }

--- a/src/hooks/useDeleteVariable.ts
+++ b/src/hooks/useDeleteVariable.ts
@@ -1,8 +1,9 @@
 import { useFigmaTokenContext } from 'contexts/useFigmaTokenContext'
 import { useMutation } from 'hooks/useMutation'
 import {
-  FIGMA_VARIABLE_BY_ID_ENDPOINT,
+  FIGMA_FILE_VARIABLES_PATH,
   ERROR_MSG_TOKEN_REQUIRED,
+  ERROR_MSG_TOKEN_FILE_KEY_REQUIRED,
 } from 'constants/index'
 import { mutator } from 'api/mutator'
 
@@ -30,17 +31,22 @@ import { mutator } from 'api/mutator'
  * @public
  */
 export const useDeleteVariable = () => {
-  const { token } = useFigmaTokenContext()
+  const { token, fileKey } = useFigmaTokenContext()
   const mutation = useMutation(async (variableId: string) => {
     if (!token) {
       throw new Error(ERROR_MSG_TOKEN_REQUIRED)
     }
-    return await mutator(
-      FIGMA_VARIABLE_BY_ID_ENDPOINT(variableId),
-      token,
-      'DELETE',
-      undefined as unknown as Record<string, unknown>
-    )
+    if (!fileKey) {
+      throw new Error(ERROR_MSG_TOKEN_FILE_KEY_REQUIRED)
+    }
+    return await mutator(FIGMA_FILE_VARIABLES_PATH(fileKey), token, 'CREATE', {
+      variables: [
+        {
+          action: 'DELETE',
+          id: variableId,
+        },
+      ],
+    } as unknown as Record<string, unknown>)
   })
   return mutation
 }

--- a/src/hooks/useUpdateVariable.ts
+++ b/src/hooks/useUpdateVariable.ts
@@ -2,8 +2,9 @@ import { useFigmaTokenContext } from 'contexts/useFigmaTokenContext'
 import { useMutation } from 'hooks/useMutation'
 import type { UpdateVariablePayload } from 'types/mutations'
 import {
-  FIGMA_VARIABLE_BY_ID_ENDPOINT,
+  FIGMA_FILE_VARIABLES_PATH,
   ERROR_MSG_TOKEN_REQUIRED,
+  ERROR_MSG_TOKEN_FILE_KEY_REQUIRED,
 } from 'constants/index'
 import { mutator } from 'api/mutator'
 
@@ -31,7 +32,7 @@ import { mutator } from 'api/mutator'
  * @public
  */
 export const useUpdateVariable = () => {
-  const { token } = useFigmaTokenContext()
+  const { token, fileKey } = useFigmaTokenContext()
   const mutation = useMutation(
     async ({
       variableId,
@@ -43,11 +44,22 @@ export const useUpdateVariable = () => {
       if (!token) {
         throw new Error(ERROR_MSG_TOKEN_REQUIRED)
       }
+      if (!fileKey) {
+        throw new Error(ERROR_MSG_TOKEN_FILE_KEY_REQUIRED)
+      }
       return await mutator(
-        FIGMA_VARIABLE_BY_ID_ENDPOINT(variableId),
+        FIGMA_FILE_VARIABLES_PATH(fileKey),
         token,
-        'UPDATE',
-        payload as unknown as Record<string, unknown>
+        'CREATE',
+        {
+          variables: [
+            {
+              action: 'UPDATE',
+              id: variableId,
+              ...payload,
+            },
+          ],
+        } as unknown as Record<string, unknown>
       )
     }
   )

--- a/tests/hooks/useUpdateVariable.test.tsx
+++ b/tests/hooks/useUpdateVariable.test.tsx
@@ -6,8 +6,9 @@ import { useUpdateVariable } from '../../src/hooks/useUpdateVariable'
 import * as FigmaTokenHook from '../../src/contexts/useFigmaTokenContext'
 import { mutator } from '../../src/api/mutator'
 import {
-  FIGMA_VARIABLE_BY_ID_ENDPOINT,
   ERROR_MSG_TOKEN_REQUIRED,
+  ERROR_MSG_TOKEN_FILE_KEY_REQUIRED,
+  FIGMA_FILE_VARIABLES_PATH,
 } from '../../src/constants/index'
 import type { UpdateVariablePayload } from '../../src/types/mutations'
 
@@ -20,6 +21,28 @@ describe('useUpdateVariable', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.restoreAllMocks()
+  })
+
+  it('should return an error state if figma fileKey is not provided', async () => {
+    const spy = vi
+      .spyOn(FigmaTokenHook, 'useFigmaTokenContext')
+      .mockReturnValue({ token: 'test-token', fileKey: null })
+
+    const { result } = renderHook(() => useUpdateVariable())
+
+    await act(async () => {
+      await result.current.mutate({
+        variableId: 'some-id',
+        payload: { name: 'test' },
+      })
+    })
+
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error?.message).toBe(
+      ERROR_MSG_TOKEN_FILE_KEY_REQUIRED
+    )
+
+    spy.mockRestore()
   })
 
   it('should return an error state if figma token is not provided', async () => {
@@ -62,14 +85,22 @@ describe('useUpdateVariable', () => {
     })
 
     const expectedToken = process.env.VITE_FIGMA_TOKEN
-    const expectedEndpoint = FIGMA_VARIABLE_BY_ID_ENDPOINT(variableId)
+    const expectedFileKey = process.env.VITE_FIGMA_FILE_KEY
 
     expect(mockedMutator).toHaveBeenCalledTimes(1)
     expect(mockedMutator).toHaveBeenCalledWith(
-      expectedEndpoint,
+      FIGMA_FILE_VARIABLES_PATH(expectedFileKey!),
       expectedToken,
-      'UPDATE',
-      payload
+      'CREATE',
+      {
+        variables: [
+          {
+            action: 'UPDATE',
+            id: variableId,
+            ...payload,
+          },
+        ],
+      }
     )
   })
 


### PR DESCRIPTION
# Summary

- Refactors variable mutation hooks to use the official Figma Variables bulk endpoint: POST /v1/files/:file_key/variables.

# Motivation

- Figma Variables REST API performs create/update/delete via one file-scoped bulk endpoint.
- Modeling single-variable PUT/DELETE endpoints is incorrect and risks runtime failures.

# Changes

- **Constants**
- Add FIGMA_FILE_VARIABLES_PATH(fileKey) for the file-scoped bulk endpoint.
- **Hooks**
- useBulkUpdateVariables now requires fileKey and calls FIGMA_FILE_VARIABLES_PATH(fileKey).
- useCreateVariable wraps payload into variables[] with action CREATE.
- useUpdateVariable wraps payload into variables[] with action UPDATE.
- useDeleteVariable wraps payload into variables[] with action DELETE.
- **Validation**
- All write hooks throw ERROR_MSG_TOKEN_FILE_KEY_REQUIRED when fileKey is missing.
- **Tests**
- Updated unit tests to assert correct endpoint and bulk payload structure.

# Verification

- pnpm test