### PR TITLE
fix(cache): prevent fallback data from caching under live SWR keys

### DIFF
--- a/src/utils/swrKeys.ts
+++ b/src/utils/swrKeys.ts
@@ -40,6 +40,11 @@ export interface PublishedVariablesKeyParams {
 /**
  * Constructs the SWR cache key for local variables.
  *
+ * @remarks
+ * If fallback is available, always returns a fallback key to prevent
+ * fallback data from being cached under live API keys. This ensures
+ * cache isolation between fallback and live data sources.
+ *
  * @param params - Key construction parameters
  * @returns SWR key tuple, or null if no valid key can be constructed
  *
@@ -50,15 +55,16 @@ export function getVariablesKey(
 ): readonly [string, string] | null {
   const { fileKey, token, providerId, hasFallback } = params
 
-  const hasLive = Boolean(token && fileKey)
-
-  if (hasLive && token && fileKey) {
-    const url = `https://api.figma.com/v1/files/${fileKey}/variables/local`
-    return [url, token] as const
-  }
-
+  // If fallback is available, always use fallback key to prevent
+  // fallback data from being cached under live API keys
   if (hasFallback) {
     return [`fallback-${providerId ?? 'default'}`, 'fallback'] as const
+  }
+
+  // Only use live key if no fallback and we have credentials
+  if (token && fileKey) {
+    const url = `https://api.figma.com/v1/files/${fileKey}/variables/local`
+    return [url, token] as const
   }
 
   return null
@@ -66,6 +72,11 @@ export function getVariablesKey(
 
 /**
  * Constructs the SWR cache key for published variables.
+ *
+ * @remarks
+ * If fallback is available, always returns a fallback key to prevent
+ * fallback data from being cached under live API keys. This ensures
+ * cache isolation between fallback and live data sources.
  *
  * @param params - Key construction parameters
  * @returns SWR key tuple, or null if no valid key can be constructed
@@ -77,15 +88,16 @@ export function getPublishedVariablesKey(
 ): readonly [string, string] | null {
   const { fileKey, token, providerId, hasFallback } = params
 
-  const hasLive = Boolean(token && fileKey)
-
-  if (hasLive && token && fileKey) {
-    const url = `https://api.figma.com/v1/files/${fileKey}/variables/published`
-    return [url, token] as const
-  }
-
+  // If fallback is available, always use fallback key to prevent
+  // fallback data from being cached under live API keys
   if (hasFallback) {
     return [`fallback-${providerId ?? 'default'}`, 'fallback'] as const
+  }
+
+  // Only use live key if no fallback and we have credentials
+  if (token && fileKey) {
+    const url = `https://api.figma.com/v1/files/${fileKey}/variables/published`
+    return [url, token] as const
   }
 
   return null

--- a/tests/hooks/usePublishedVariables.test.tsx
+++ b/tests/hooks/usePublishedVariables.test.tsx
@@ -385,6 +385,8 @@ describe('usePublishedVariables', () => {
 
   it('should test custom fetcher logic directly for published endpoint', async () => {
     // Test the actual custom fetcher logic by calling it directly
+    // When fallbackFile is present, the key should be a fallback key (not live key)
+    // This ensures fallback data is cached under fallback keys, preventing cache pollution
     renderHook(() => usePublishedVariables(), {
       wrapper: wrapperWithFallbackFile,
     })
@@ -399,11 +401,12 @@ describe('usePublishedVariables', () => {
       unknown,
       (url: string, token: string) => Promise<unknown>,
     ]
-    // Verify it's using the published endpoint with absolute URL
-    expect(key).toEqual([
-      'https://api.figma.com/v1/files/test-key/variables/published',
-      'test-token',
-    ])
+    // Key should be fallback key (not live key) when fallbackFile is present
+    // This prevents fallback data from being cached under live API keys
+    expect(Array.isArray(key)).toBe(true)
+    const keyArray = key as [string, string]
+    expect(keyArray[0]).toMatch(/^fallback-figma-vars-provider-/)
+    expect(keyArray[1]).toBe('fallback')
     expect(typeof fetcher).toBe('function')
 
     // Call the custom fetcher directly to test the fallbackFile logic

--- a/tests/hooks/useVariables.test.tsx
+++ b/tests/hooks/useVariables.test.tsx
@@ -377,6 +377,8 @@ describe('useVariables', () => {
 
   it('should test custom fetcher logic directly', async () => {
     // Test the actual custom fetcher logic by calling it directly
+    // When fallbackFile is present, the key should be a fallback key (not live key)
+    // This ensures fallback data is cached under fallback keys, preventing cache pollution
     renderHook(() => useVariables(), { wrapper: wrapperWithFallbackFile })
 
     // Get the custom fetcher function from the useSWR call
@@ -389,10 +391,12 @@ describe('useVariables', () => {
       unknown,
       (url: string, token: string) => Promise<unknown>,
     ]
-    expect(key).toEqual([
-      'https://api.figma.com/v1/files/test-key/variables/local',
-      'test-token',
-    ])
+    // Key should be fallback key (not live key) when fallbackFile is present
+    // This prevents fallback data from being cached under live API keys
+    expect(Array.isArray(key)).toBe(true)
+    const keyArray = key as [string, string]
+    expect(keyArray[0]).toMatch(/^fallback-figma-vars-provider-/)
+    expect(keyArray[1]).toBe('fallback')
     expect(typeof fetcher).toBe('function')
 
     // Call the custom fetcher directly to test the fallbackFile logic


### PR DESCRIPTION
BREAKING CHANGE: When both credentials and fallback data are present, the SWR key now prioritizes the fallback key instead of the live API key.

Problem:
- When token/fileKey AND fallbackFile were both provided, getVariablesKey() and getPublishedVariablesKey() returned live API URL keys
- The fetcher functions checked for parsedFallbackFile first and returned it
- This caused fallback data to be cached under live API URL keys
- Result: Cache pollution where fallback data appeared as live API data

Solution:
- Reordered key generation logic to check hasFallback FIRST
- If fallback is present, always return fallback-scoped key
- This ensures fallback data is cached under fallback keys only
- Live API data is cached under live keys only

Files changed:
- src/utils/swrKeys.ts: Reordered logic in getVariablesKey() and getPublishedVariablesKey() to prioritize fallback keys
- tests/hooks/useVariables.test.tsx: Updated test expectations to match new correct behavior (fallback key when fallback present)
- tests/hooks/usePublishedVariables.test.tsx: Same test updates