### PR TITLE
fix(api): improve error parsing for non-JSON API responses

### DIFF
--- a/src/api/mutator.ts
+++ b/src/api/mutator.ts
@@ -153,15 +153,29 @@ export async function mutator<TResponse = unknown>(
         }
       }
 
-      // Try to extract error message from JSON response
+      // Try to extract error message from response body
       try {
-        const contentType = response.headers.get('content-type')
-        if (contentType?.includes('application/json')) {
+        const contentType = response.headers.get('content-type') ?? ''
+        if (contentType.includes('application/json')) {
           const errorData = await response.json()
           errorMessage = errorData.err || errorData.message || errorMessage
+        } else if (
+          contentType.includes('text/plain') ||
+          contentType.includes('text/html')
+        ) {
+          // For text responses (e.g., 502 Bad Gateway), use the body text
+          const textBody = await response.text()
+          if (textBody) {
+            // Truncate long HTML/text responses to a reasonable length
+            const maxLength = 200
+            errorMessage =
+              textBody.length > maxLength
+                ? `${textBody.slice(0, maxLength)}...`
+                : textBody
+          }
         }
       } catch {
-        // Ignore JSON parse errors, use default message
+        // Ignore parse errors, use default message
       }
 
       throw new FigmaApiError(errorMessage, statusCode, retryAfter)


### PR DESCRIPTION
Add support for extracting error messages from text/plain and text/html responses, which can occur during gateway errors (502, 503) or when the API returns HTML error pages.

Problem:
- When Figma API returned non-JSON errors (e.g., 502 Bad Gateway with HTML), users would only see generic error message with no debugging context
- No visibility into actual error content for troubleshooting

Solution:
- Check content-type header before parsing response body
- For application/json: parse as JSON (existing behavior)
- For text/plain or text/html: read body as text and use as error message
- Truncate long responses (>200 chars) to prevent huge error messages
- Gracefully handle empty bodies and parsing errors

Changes:
- src/api/fetcher.ts: Added text/plain and text/html response handling
- src/api/mutator.ts: Added text/plain and text/html response handling
- tests/api/fetcher.test.ts: Added 7 tests for text error responses
- tests/api/mutator.test.ts: Added 7 tests for text error responses

Test coverage: 100%