### PR TITLE
docs(mutations): document return type semantics for mutation hooks

### DIFF
--- a/src/hooks/useBulkUpdateVariables.ts
+++ b/src/hooks/useBulkUpdateVariables.ts
@@ -15,21 +15,35 @@ import { mutator } from 'api/mutator'
  * This hook is designed to perform a batch operation for creating, updating, and deleting variables, collections, and modes.
  * It provides an ergonomic API with `mutate` and loading/error state for easy integration.
  *
+ * ## Return Value
+ *
+ * The `mutate` function returns `Promise<TData | undefined>`:
+ * - On success: Returns the API response data
+ * - On error: Returns `undefined` (error stored in `error` state)
+ *
+ * Use `isSuccess`/`isError` flags or check the return value to handle results.
+ *
+ * @returns MutationResult with `mutate`, status flags (`isLoading`, `isSuccess`, `isError`),
+ * `data` (API response), and `error` (if failed).
+ *
  * @example
  * ```tsx
  * import { useBulkUpdateVariables } from '@figma-vars/hooks';
  *
  * function BulkUpdateButton() {
- *   const { mutate, isLoading, error } = useBulkUpdateVariables();
+ *   const { mutate, isLoading, isError, error } = useBulkUpdateVariables();
  *
- *   const handleBulkUpdate = () => {
- *     mutate({
+ *   const handleBulkUpdate = async () => {
+ *     const result = await mutate({
  *       variables: [{ action: 'UPDATE', id: 'VariableId:123', name: 'new-name' }],
  *     });
+ *     if (result) {
+ *       console.log('Bulk update successful');
+ *     }
  *   };
  *
  *   if (isLoading) return <div>Updating...</div>;
- *   if (error) return <div>Error: {error.message}</div>;
+ *   if (isError) return <div>Error: {error?.message}</div>;
  *   return <button onClick={handleBulkUpdate}>Bulk Update</button>;
  * }
  * ```

--- a/src/hooks/useCreateVariable.ts
+++ b/src/hooks/useCreateVariable.ts
@@ -14,19 +14,37 @@ import { mutator } from 'api/mutator'
  * @remarks
  * The hook returns a `mutate` function to trigger the creation along with state flags and data.
  *
+ * ## Return Value
+ *
+ * The `mutate` function returns `Promise<TData | undefined>`:
+ * - On success: Returns the API response data
+ * - On error: Returns `undefined` (error stored in `error` state)
+ *
+ * Use `isSuccess`/`isError` flags or check the return value to handle results.
+ *
+ * @returns MutationResult with `mutate`, status flags (`isLoading`, `isSuccess`, `isError`),
+ * `data` (API response), and `error` (if failed).
+ *
  * @example
  * ```tsx
  * import { useCreateVariable } from '@figma-vars/hooks';
  *
  * function CreateVariableButton() {
- *   const { mutate, isLoading, error } = useCreateVariable();
+ *   const { mutate, isLoading, isError, error } = useCreateVariable();
  *
- *   const handleCreate = () => {
- *     mutate({ name: 'new-variable', variableCollectionId: 'VariableCollectionId:1:1', resolvedType: 'COLOR' });
+ *   const handleCreate = async () => {
+ *     const result = await mutate({
+ *       name: 'new-variable',
+ *       variableCollectionId: 'VariableCollectionId:1:1',
+ *       resolvedType: 'COLOR'
+ *     });
+ *     if (result) {
+ *       console.log('Created successfully:', result);
+ *     }
  *   };
  *
  *   if (isLoading) return <div>Creating...</div>;
- *   if (error) return <div>Error: {error.message}</div>;
+ *   if (isError) return <div>Error: {error?.message}</div>;
  *   return <button onClick={handleCreate}>Create Variable</button>;
  * }
  * ```

--- a/src/hooks/useDeleteVariable.ts
+++ b/src/hooks/useDeleteVariable.ts
@@ -13,17 +13,33 @@ import { mutator } from 'api/mutator'
  * @remarks
  * This hook provides a `mutate` function to trigger the deletion and exposes loading and error states.
  *
+ * ## Return Value
+ *
+ * The `mutate` function returns `Promise<TData | undefined>`:
+ * - On success: Returns the API response data
+ * - On error: Returns `undefined` (error stored in `error` state)
+ *
+ * Use `isSuccess`/`isError` flags or check the return value to handle results.
+ *
+ * @returns MutationResult with `mutate`, status flags (`isLoading`, `isSuccess`, `isError`),
+ * `data` (API response), and `error` (if failed).
+ *
  * @example
  * ```tsx
  * import { useDeleteVariable } from '@figma-vars/hooks';
  *
  * function DeleteVariableButton({ id }: { id: string }) {
- *   const { mutate, isLoading, error } = useDeleteVariable();
+ *   const { mutate, isLoading, isError, error } = useDeleteVariable();
  *
- *   const onDelete = () => mutate(id);
+ *   const onDelete = async () => {
+ *     const result = await mutate(id);
+ *     if (result) {
+ *       console.log('Deleted successfully');
+ *     }
+ *   };
  *
  *   if (isLoading) return <div>Deleting...</div>;
- *   if (error) return <div>Error: {error.message}</div>;
+ *   if (isError) return <div>Error: {error?.message}</div>;
  *   return <button onClick={onDelete}>Delete Variable</button>;
  * }
  * ```

--- a/src/hooks/useUpdateVariable.ts
+++ b/src/hooks/useUpdateVariable.ts
@@ -14,17 +14,33 @@ import { mutator } from 'api/mutator'
  * @remarks
  * The hook returns a `mutate` function to trigger the update with given payload and exposes state flags.
  *
+ * ## Return Value
+ *
+ * The `mutate` function returns `Promise<TData | undefined>`:
+ * - On success: Returns the API response data
+ * - On error: Returns `undefined` (error stored in `error` state)
+ *
+ * Use `isSuccess`/`isError` flags or check the return value to handle results.
+ *
+ * @returns MutationResult with `mutate`, status flags (`isLoading`, `isSuccess`, `isError`),
+ * `data` (API response), and `error` (if failed).
+ *
  * @example
  * ```tsx
  * import { useUpdateVariable } from '@figma-vars/hooks';
  *
  * function UpdateVariableButton({ id }: { id: string }) {
- *   const { mutate, isLoading, error } = useUpdateVariable();
+ *   const { mutate, isLoading, isError, error } = useUpdateVariable();
  *
- *   const onUpdate = () => mutate({ variableId: id, payload: { name: 'new-name' } });
+ *   const onUpdate = async () => {
+ *     const result = await mutate({ variableId: id, payload: { name: 'new-name' } });
+ *     if (result) {
+ *       console.log('Updated successfully');
+ *     }
+ *   };
  *
  *   if (isLoading) return <div>Updating...</div>;
- *   if (error) return <div>Error: {error.message}</div>;
+ *   if (isError) return <div>Error: {error?.message}</div>;
  *   return <button onClick={onUpdate}>Update Variable</button>;
  * }
  * ```

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -122,7 +122,7 @@ export function withRetry<T>(
     }
 
     // This should never be reached, but TypeScript needs it
-    /* istanbul ignore next */
+    /* c8 ignore next */
     throw lastError ?? new Error('Retry failed')
   }
 }


### PR DESCRIPTION
Add comprehensive JSDoc documentation explaining mutation return value behavior:

- MutationResult interface: Detailed docs with code examples showing all three patterns (check return value, try/catch, reactive status flags)
- MutationOptions.throwOnError: Clear explanation of both modes
- useCreateVariable: Added return value section and improved example
- useUpdateVariable: Added return value section and improved example
- useDeleteVariable: Added return value section and improved example
- useBulkUpdateVariables: Added return value section and improved example

Key documentation points:
- mutate() returns Promise<TData | undefined>
- On success: returns TData
- On error (throwOnError: false): returns undefined, error in state
- On error (throwOnError: true): throws error

Also fixes:
- src/utils/retry.ts: Changed /* istanbul ignore next */ to /* c8 ignore next */ for proper Codecov/Vitest V8 coverage exclusion